### PR TITLE
Nick 19 api route sponsors

### DIFF
--- a/app/api/sponsor/[id]/route.ts
+++ b/app/api/sponsor/[id]/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SponsorService } from "@/services/SponsorService";
+import { checkAuth } from "@/utils/checkAuth";
+
+export const GET = checkAuth(
+    async (req: NextRequest, { params }: { params: { id: string } }) => {
+        const id = Number(params.id);
+        if (isNaN(id)) {
+            return NextResponse.json(
+                { message: "Invalid id" },
+                { status: 400 },
+            );
+        }
+
+        try {
+            const sponsor = await SponsorService.getSponsorById(id);
+
+            if (!sponsor) {
+                return NextResponse.json(
+                    { message: "Sponsor not found" },
+                    { status: 404 },
+                );
+            }
+
+            return NextResponse.json(sponsor);
+        } catch (err) {
+            console.error(err);
+            return NextResponse.json(
+                { message: "Internal server error" },
+                { status: 500 },
+            );
+        }
+    },
+);
+
+export const PUT = checkAuth(
+    async (req: NextRequest, { params }: { params: { id: string } }) => {
+        const id = Number(params.id);
+        if (isNaN(id)) {
+            return NextResponse.json(
+                { message: "Invalid id" },
+                { status: 400 },
+            );
+        }
+
+        const data = await req.json();
+
+        try {
+            const updatedSponsor = await SponsorService.updateSponsor(id, data);
+            return NextResponse.json(
+                {
+                    message: "Sponsor updated successfully",
+                    data: updatedSponsor,
+                },
+                { status: 200 },
+            );
+        } catch (err) {
+            console.error(err);
+            return NextResponse.json(
+                { message: "Internal server error" },
+                { status: 500 },
+            );
+        }
+    },
+);
+
+export const DELETE = checkAuth(
+    async (req: NextRequest, { params }: { params: { id: string } }) => {
+        const id = Number(params.id);
+        if (isNaN(id)) {
+            return NextResponse.json(
+                { message: "Invalid id" },
+                { status: 400 },
+            );
+        }
+
+        try {
+            await SponsorService.deleteSponsor(id);
+            return NextResponse.json(
+                { message: "Sponsor deleted successfully" },
+                { status: 200 },
+            );
+        } catch (err) {
+            console.error(err);
+            return NextResponse.json(
+                { message: "Internal server error" },
+                { status: 500 },
+            );
+        }
+    },
+);

--- a/app/api/sponsor/route.ts
+++ b/app/api/sponsor/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SponsorService } from "@/services/SponsorService";
+import { checkAuth } from "@/utils/checkAuth";
+
+export const POST = checkAuth(async (req: NextRequest) => {
+    try {
+        const data = await req.json();
+        const newSponsor = await SponsorService.addSponsor(data);
+        return NextResponse.json(
+            { message: "Successfully created sponsor", data: newSponsor },
+            {
+                status: 201,
+            },
+        );
+    } catch (error) {
+        console.error("Error creating sponsor:", error);
+        return NextResponse.json(
+            { error: "Failed to create sponsor" },
+            { status: 500 },
+        );
+    }
+});
+
+export const GET = checkAuth(async () => {
+    try {
+        const sponsors = await SponsorService.getAllSponsors();
+        return NextResponse.json(
+            { message: "Successfully fetched all Sponsors", data: sponsors },
+            {
+                status: 200,
+            },
+        );
+    } catch (error) {
+        console.error("Error fetching all sponsors:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch all sponsors" },
+            { status: 500 },
+        );
+    }
+});
+
+export const DELETE = checkAuth(async () => {
+    try {
+        const sponsors = await SponsorService.deleteAllCategories();
+        return NextResponse.json(`Deleted ${sponsors.count} sponsors.`, {
+            status: 200,
+        });
+    } catch (error) {
+        console.error("Error deleting all sponsors:", error);
+        return NextResponse.json(
+            { error: "Failed to delete all sponsors" },
+            { status: 500 },
+        );
+    }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,9 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
-// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
-
 generator client {
   provider = "prisma-client-ts"
   output   = "../app/generated/prisma"
@@ -18,15 +12,15 @@ model User {
   createdAt     DateTime  @default(now())
   email         String    @unique
   name          String
-  role          String?   @default("user")
   emailVerified Boolean   @default(false)
   image         String?
   updatedAt     DateTime  @updatedAt
-  sessions      Session[]
-  accounts      Account[]
-  banned        Boolean?
-  banReason     String?
   banExpires    DateTime?
+  banReason     String?
+  banned        Boolean?
+  role          String?   @default("user")
+  accounts      Account[]
+  sessions      Session[]
 
   @@map("user")
 }
@@ -35,13 +29,13 @@ model Event {
   id            Int                  @id @default(autoincrement())
   createdAt     DateTime             @default(now())
   name          String               @unique
-  categories    CategoriesOnEvents[]
   date          DateTime
-  location      Location             @relation(fields: [locationId], references: [id])
-  locationId    Int
   description   String
   link          String
+  locationId    Int
   thumbnailPath String
+  categories    CategoriesOnEvents[]
+  location      Location             @relation(fields: [locationId], references: [id])
 }
 
 model Location {
@@ -60,11 +54,11 @@ model Category {
 }
 
 model CategoriesOnEvents {
-  event      Event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
   eventId    Int
-  category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
   categoryId Int
   assignedAt DateTime @default(now())
+  category   Category @relation(fields: [categoryId], references: [id])
+  event      Event    @relation(fields: [eventId], references: [id])
 
   @@id([eventId, categoryId])
 }
@@ -73,9 +67,10 @@ model Sponsor {
   id            Int         @id @default(autoincrement())
   createdAt     DateTime    @default(now())
   name          String      @unique
-  sponsorTier   SponsorTier @relation(fields: [sponsorTierId], references: [id])
   sponsorTierId Int
-  image_url         String?
+  image_url     String
+  link          String
+  sponsorTier   SponsorTier @relation(fields: [sponsorTierId], references: [id])
 }
 
 model SponsorTier {
@@ -86,20 +81,18 @@ model SponsorTier {
 }
 
 model Session {
-  id            String   @id
-  expiresAt     DateTime
-  token         String
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
-  ipAddress     String?
-  userAgent     String?
-  userId        String
-  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  impersonateBy String?
-
+  id             String   @id
+  expiresAt      DateTime
+  token          String   @unique
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  ipAddress      String?
+  userAgent      String?
+  userId         String
+  impersonateBy  String?
   impersonatedBy String?
+  user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@unique([token])
   @@index([userId])
   @@map("session")
 }
@@ -109,7 +102,6 @@ model Account {
   accountId             String
   providerId            String
   userId                String
-  user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   accessToken           String?
   refreshToken          String?
   idToken               String?
@@ -119,6 +111,7 @@ model Account {
   password              String?
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
+  user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@map("account")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,82 +8,84 @@ const adapter = new PrismaPg(pool);
 const prisma = new PrismaClient({
     adapter,
 });
-async function main() {
-    const gold = await prisma.sponsorTier.upsert({
-        where: { name: "gold" },
-        update: {
-            sponsor: {
-                create: [
-                    {
-                        name: "me",
-                        image_url:
-                            "https://cdn.britannica.com/44/4144-004-43DD2776/Peneus-setiferus.jpg",
-                    },
-                    {
-                        name: "justin",
-                        image_url:
-                            "https://static.wikia.nocookie.net/tekken/images/0/0c/Yoshimitsu_TK8_render_%28High_Resolution%29.jpg/revision/latest?cb=20251203015109&path-prefix=en",
-                    },
-                ],
-            },
-        },
-        create: {
-            name: "gold",
-        },
-    });
-    const silver = await prisma.sponsorTier.upsert({
-        where: { name: "silver" },
-        update: {
-            sponsor: {
-                create: [
-                    {
-                        name: "treyson",
-                        image_url:
-                            "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSOaBjpdhWvLHr1RwB6i-6AotHmQE0MKirVLA&s",
-                    },
-                    {
-                        name: "lawrence",
-                        image_url: "",
-                    },
-                ],
-            },
-        },
-        create: {
-            name: "silver",
-        },
-    });
-    const bronze = await prisma.sponsorTier.upsert({
-        where: { name: "bronze" },
-        update: {
-            sponsor: {
-                create: [
-                    {
-                        name: "dragunov",
-                        image_url:
-                            "https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg",
-                    },
-                    {
-                        name: "yoshi",
-                        image_url:
-                            "https://i.pinimg.com/474x/6f/46/01/6f46018cba280f9d00176726fec6585e.jpg",
-                    },
-                ],
-            },
-        },
-        create: {
-            name: "bronze",
-        },
-    });
-}
 
-main()
-    .then(async () => {
-        await prisma.$disconnect();
-        await pool.end();
-    })
-    .catch(async (e) => {
-        console.error(e);
-        await prisma.$disconnect();
-        await pool.end();
-        process.exit(1);
-    });
+//Test data for SponsorTier and Sponsors (outdated schema for Sponsor table)
+// async function main() {
+//     const gold = await prisma.sponsorTier.upsert({
+//         where: { name: "gold" },
+//         update: {
+//             sponsor: {
+//                 create: [
+//                     {
+//                         name: "me",
+//                         image_url:
+//                             "https://cdn.britannica.com/44/4144-004-43DD2776/Peneus-setiferus.jpg",
+//                     },
+//                     {
+//                         name: "justin",
+//                         image_url:
+//                             "https://static.wikia.nocookie.net/tekken/images/0/0c/Yoshimitsu_TK8_render_%28High_Resolution%29.jpg/revision/latest?cb=20251203015109&path-prefix=en",
+//                     },
+//                 ],
+//             },
+//         },
+//         create: {
+//             name: "gold",
+//         },
+//     });
+//     const silver = await prisma.sponsorTier.upsert({
+//         where: { name: "silver" },
+//         update: {
+//             sponsor: {
+//                 create: [
+//                     {
+//                         name: "treyson",
+//                         image_url:
+//                             "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSOaBjpdhWvLHr1RwB6i-6AotHmQE0MKirVLA&s",
+//                     },
+//                     {
+//                         name: "lawrence",
+//                         image_url: "",
+//                     },
+//                 ],
+//             },
+//         },
+//         create: {
+//             name: "silver",
+//         },
+//     });
+//     const bronze = await prisma.sponsorTier.upsert({
+//         where: { name: "bronze" },
+//         update: {
+//             sponsor: {
+//                 create: [
+//                     {
+//                         name: "dragunov",
+//                         image_url:
+//                             "https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg",
+//                     },
+//                     {
+//                         name: "yoshi",
+//                         image_url:
+//                             "https://i.pinimg.com/474x/6f/46/01/6f46018cba280f9d00176726fec6585e.jpg",
+//                     },
+//                 ],
+//             },
+//         },
+//         create: {
+//             name: "bronze",
+//         },
+//     });
+// }
+
+// main()
+//     .then(async () => {
+//         await prisma.$disconnect();
+//         await pool.end();
+//     })
+//     .catch(async (e) => {
+//         console.error(e);
+//         await prisma.$disconnect();
+//         await pool.end();
+//         process.exit(1);
+//     });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,26 +1,89 @@
-import 'dotenv/config'
+import "dotenv/config";
 import { PrismaClient, Prisma } from "../app/generated/prisma/client";
-import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
 
-
-const adapter = new PrismaPg({
-    connectionString: process.env.DATABASE_URL,
-})
-
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const adapter = new PrismaPg(pool);
 const prisma = new PrismaClient({
     adapter,
 });
-
-const categoryData: Prisma.CategoryCreateInput[] = [
-    {
-        name: "TEKKEN 8",
-    },
-];
-
-export async function main() {
-    for (const u of categoryData) {
-        await prisma.category.create({ data: u });
-    }
+async function main() {
+    const gold = await prisma.sponsorTier.upsert({
+        where: { name: "gold" },
+        update: {
+            sponsor: {
+                create: [
+                    {
+                        name: "me",
+                        image_url:
+                            "https://cdn.britannica.com/44/4144-004-43DD2776/Peneus-setiferus.jpg",
+                    },
+                    {
+                        name: "justin",
+                        image_url:
+                            "https://static.wikia.nocookie.net/tekken/images/0/0c/Yoshimitsu_TK8_render_%28High_Resolution%29.jpg/revision/latest?cb=20251203015109&path-prefix=en",
+                    },
+                ],
+            },
+        },
+        create: {
+            name: "gold",
+        },
+    });
+    const silver = await prisma.sponsorTier.upsert({
+        where: { name: "silver" },
+        update: {
+            sponsor: {
+                create: [
+                    {
+                        name: "treyson",
+                        image_url:
+                            "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSOaBjpdhWvLHr1RwB6i-6AotHmQE0MKirVLA&s",
+                    },
+                    {
+                        name: "lawrence",
+                        image_url: "",
+                    },
+                ],
+            },
+        },
+        create: {
+            name: "silver",
+        },
+    });
+    const bronze = await prisma.sponsorTier.upsert({
+        where: { name: "bronze" },
+        update: {
+            sponsor: {
+                create: [
+                    {
+                        name: "dragunov",
+                        image_url:
+                            "https://upload.wikimedia.org/wikipedia/commons/b/b2/Hausziege_04.jpg",
+                    },
+                    {
+                        name: "yoshi",
+                        image_url:
+                            "https://i.pinimg.com/474x/6f/46/01/6f46018cba280f9d00176726fec6585e.jpg",
+                    },
+                ],
+            },
+        },
+        create: {
+            name: "bronze",
+        },
+    });
 }
 
-main();
+main()
+    .then(async () => {
+        await prisma.$disconnect();
+        await pool.end();
+    })
+    .catch(async (e) => {
+        console.error(e);
+        await prisma.$disconnect();
+        await pool.end();
+        process.exit(1);
+    });

--- a/services/SponsorService.ts
+++ b/services/SponsorService.ts
@@ -1,0 +1,48 @@
+import prisma from "@/lib/prisma";
+import {
+    SponsorUncheckedCreateInput,
+    SponsorUpdateInput,
+} from "@/app/generated/prisma/models";
+import { string } from "better-auth";
+
+export class SponsorService {
+    static async addSponsor(data: SponsorUncheckedCreateInput) {
+        return prisma.sponsor.create({
+            data: {
+                name: data.name,
+                sponsorTier: { connect: { id: data.sponsorTierId } },
+                image_url: data.image_url,
+                link: data.link,
+            },
+        });
+    }
+
+    static async getAllSponsors() {
+        return prisma.sponsor.findMany();
+    }
+
+    static async getSponsorById(id: number) {
+        const sponsor = await prisma.sponsor.findUnique({ where: { id } });
+        if (!sponsor) {
+            return null;
+        }
+        return sponsor;
+    }
+
+    static async updateSponsor(id: number, data: SponsorUpdateInput) {
+        return prisma.sponsor.update({
+            where: { id },
+            data,
+        });
+    }
+
+    static async deleteSponsor(id: number) {
+        return prisma.sponsor.delete({
+            where: { id },
+        });
+    }
+
+    static async deleteAllCategories() {
+        return prisma.sponsor.deleteMany();
+    }
+}


### PR DESCRIPTION
closes #19 create api routes for sponsor

## Context

Making this change because Treyson told me too

## What Changed?

Added sponsor service class to expose functions to api route, including dynamic api route. Added functions to get all sponsors, get sponsor by id, create sponsor, update sponsor, delete all sponsor, and delete sponsor by id. 

## How To Review

any

## Testing

Used Postman to generate JSON output by testing both the api route and dynamic api route for different functions 

## Risks

hopefully nothing 

## Notes

I have no clue who migrated the new prisma schema but that nearly broke me because I had no clue what was wrong with my api routes. Took solid 2 hours of claude to debug (which was kinda my bad because I could have pay more attention to the error message since the start). Maybe pulling a db schema is standard practice but I would love it if any changes to schema could be communicated beforehand.